### PR TITLE
add "h" to fix typo from "hypens" to "hyphens"

### DIFF
--- a/src/client/coffee/appView.coffee
+++ b/src/client/coffee/appView.coffee
@@ -36,7 +36,7 @@ class AppView extends Backbone.View
           input ".edit-form-text.js-input", "type": "text"
           p ".error.hidden.js-error-invalid", ->
             span ".js-error-too-many-words.hidden", "Only one word is allowed. "
-            span ".js-error-invalid-characters.hidden", "No spaces or punctuation (except hypens) are accepted. "
+            span ".js-error-invalid-characters.hidden", "No spaces or punctuation (except hyphens) are accepted. "
             text "Your word will be “"
             span ".js-validated-output"
             text "”."


### PR DESCRIPTION
Found this silly typo.

![hypens-typo](https://cloud.githubusercontent.com/assets/6025036/8657486/e3f7ba98-296b-11e5-8cd5-b9f8fa3cf657.png)

I'm not familiar with the build process, so I didn't know how to test that my change is helpful, but "hypens" is there in the wild, and the typo that I fixed seems to be the only instance of that misspelling in the code, so I figure this change should work.

Fun app, by the way!
